### PR TITLE
Many QOL fixes for Slate editing, improved compatibility with USFM, Added usx editor

### DIFF
--- a/react-electron-poc/package-lock.json
+++ b/react-electron-poc/package-lock.json
@@ -20,7 +20,8 @@
         "react-window": "^1.8.7",
         "slate": "^0.82.1",
         "slate-history": "^0.66.0",
-        "slate-react": "^0.82.2"
+        "slate-react": "^0.82.2",
+        "usxeditor": "^0.0.9-alpha"
       },
       "devDependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
@@ -2951,6 +2952,14 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
+      "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -13660,6 +13669,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-autobind": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz",
+      "integrity": "sha512-+BTreuQUUGv1Tv4GbcFNk+1L8U60ZSdxLUs3OVUPsShzxLFYcTYcNf2wzMt3GEU4iFA8Px7SpofpX+uiL03QyQ=="
+    },
     "node_modules/react-contenteditable": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.6.tgz",
@@ -15923,6 +15937,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/usxeditor": {
+      "version": "0.0.9-alpha",
+      "resolved": "https://registry.npmjs.org/usxeditor/-/usxeditor-0.0.9-alpha.tgz",
+      "integrity": "sha512-hEfEklWvBE/2+0QT9R0xJwp2fgD+ujZKZdCsX2algVhZJskClUKuifLMkv6pOcUpc5iTykgpOc4si6xy0wN9gg==",
+      "dependencies": {
+        "react-autobind": "^1.0.6",
+        "xml-to-react": "^1.2.0-alpha.2"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -16666,6 +16692,14 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-to-react": {
+      "version": "1.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/xml-to-react/-/xml-to-react-1.2.0-alpha.2.tgz",
+      "integrity": "sha512-NM+5GxjqadRybw0NF9kinykSCTo94D5e19w7ZyeGMQYEVTbORMLJr+TnMKXdxQtSDKiC55/s6Ys7apwDe5ja9A==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.5"
       }
     },
     "node_modules/xmlbuilder": {
@@ -19063,6 +19097,11 @@
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
       "requires": {}
+    },
+    "@xmldom/xmldom": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
+      "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -27044,6 +27083,11 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-autobind": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz",
+      "integrity": "sha512-+BTreuQUUGv1Tv4GbcFNk+1L8U60ZSdxLUs3OVUPsShzxLFYcTYcNf2wzMt3GEU4iFA8Px7SpofpX+uiL03QyQ=="
+    },
     "react-contenteditable": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.6.tgz",
@@ -28745,6 +28789,15 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "usxeditor": {
+      "version": "0.0.9-alpha",
+      "resolved": "https://registry.npmjs.org/usxeditor/-/usxeditor-0.0.9-alpha.tgz",
+      "integrity": "sha512-hEfEklWvBE/2+0QT9R0xJwp2fgD+ujZKZdCsX2algVhZJskClUKuifLMkv6pOcUpc5iTykgpOc4si6xy0wN9gg==",
+      "requires": {
+        "react-autobind": "^1.0.6",
+        "xml-to-react": "^1.2.0-alpha.2"
+      }
+    },
     "utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -29284,6 +29337,14 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true
+    },
+    "xml-to-react": {
+      "version": "1.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/xml-to-react/-/xml-to-react-1.2.0-alpha.2.tgz",
+      "integrity": "sha512-NM+5GxjqadRybw0NF9kinykSCTo94D5e19w7ZyeGMQYEVTbORMLJr+TnMKXdxQtSDKiC55/s6Ys7apwDe5ja9A==",
+      "requires": {
+        "@xmldom/xmldom": "^0.7.5"
+      }
     },
     "xmlbuilder": {
       "version": "15.1.1",

--- a/react-electron-poc/package.json
+++ b/react-electron-poc/package.json
@@ -123,7 +123,8 @@
     "react-window": "^1.8.7",
     "slate": "^0.82.1",
     "slate-history": "^0.66.0",
-    "slate-react": "^0.82.2"
+    "slate-react": "^0.82.2",
+    "usxeditor": "^0.0.9-alpha"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",

--- a/react-electron-poc/src/renderer/components/panels/Panels.ts
+++ b/react-electron-poc/src/renderer/components/panels/Panels.ts
@@ -7,12 +7,13 @@ import { EditableHtmlTextPanel } from './TextPanels/EditableHtmlTextPanel';
 import {
     ScriptureTextPanelHtml,
     ScriptureTextPanelUsfm,
-    ScriptureTextPanelUsx,
+    ScriptureTextPanelUsxString,
 } from './TextPanels/ScriptureTextPanelHtml';
 import {
     ScriptureTextPanelSlate,
     ScriptureTextPanelSlateJSONFromUsx,
 } from './TextPanels/ScriptureTextPanelSlate';
+import { ScriptureTextPanelUsx } from './TextPanels/ScriptureTextPanelUsx';
 
 // TODO: Consider doing something a bit different with this https://stackoverflow.com/questions/29722270/is-it-possible-to-import-modules-from-all-files-in-a-directory-using-a-wildcard
 /** All available panels for use in dockviews */
@@ -21,10 +22,11 @@ export const Panels = {
     TextPanel,
     HtmlTextPanel,
     EditableHtmlTextPanel,
+    ScriptureTextPanelSlate,
+    ScriptureTextPanelUsx,
     ScriptureTextPanelHtml,
     ScriptureTextPanelUsfm,
-    ScriptureTextPanelUsx,
-    ScriptureTextPanelSlate,
+    ScriptureTextPanelUsxString,
     ScriptureTextPanelSlateJSONFromUsx,
 };
 export default Panels;

--- a/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelHtml.tsx
+++ b/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelHtml.tsx
@@ -13,7 +13,13 @@ import {
     parseVerse,
 } from '@util/ScriptureUtil';
 import { htmlEncode, isValidValue } from '@util/Util';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react';
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable';
 import {
     ScriptureTextPanelHOC,
@@ -276,8 +282,8 @@ export const ScriptureTextPanelUsfm = ScriptureTextPanelHOC(
     getScriptureRaw,
 );
 
-/** Scripture text panel that displays USX Scripture */
-export const ScriptureTextPanelUsx = ScriptureTextPanelHOC(
+/** Scripture text panel that displays USX Scripture strings */
+export const ScriptureTextPanelUsxString = ScriptureTextPanelHOC(
     ScriptureTextPanelString,
     async (shortName, bookNum, chapter) => {
         const scr = await getScriptureUsx(shortName, bookNum, chapter);

--- a/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelSlate.tsx
+++ b/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelSlate.tsx
@@ -193,7 +193,7 @@ interface ElementInfo {
 }
 
 /** All available elements for use in slate editor */
-const EditorElements: { [type: string]: ElementInfo } = {
+export const EditorElements: { [type: string]: ElementInfo } = {
     verse: {
         component: VerseElement,
         inline: true,

--- a/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelUsx.tsx
+++ b/react-electron-poc/src/renderer/components/panels/TextPanels/ScriptureTextPanelUsx.tsx
@@ -1,0 +1,64 @@
+import { getScriptureUsx } from '@services/ScriptureService';
+import { ScriptureChapterString } from '@shared/data/ScriptureTypes';
+import { htmlEncode } from '@util/Util';
+import { useLayoutEffect } from 'react';
+import UsxEditor from 'usxeditor';
+import {
+    ScriptureTextPanelHOC,
+    ScriptureTextPanelHOCProps,
+} from './ScriptureTextPanelHOC';
+import { EditorElements } from './ScriptureTextPanelSlate';
+
+const UsxEditorParaMap =
+    EditorElements.para.validStyles?.map((style) => style.style) || [];
+const UsxEditorCharMap = Object.fromEntries(
+    EditorElements.char.validStyles?.map((style) => [style.style, {}]) || [],
+);
+
+export interface ScriptureTextPanelUsxProps extends ScriptureTextPanelHOCProps {
+    scrChapters: ScriptureChapterString[];
+}
+
+/**
+ * Scripture text panel that inserts the chapter string into innerHTML or a contentEditable div.
+ * Used internally only in this file for displaying different kinds of strings.
+ * Originally built for Scripture HTML, so, if something doesn't work, it probably doesn't work because it's not an HTML panel.
+ */
+const ScriptureTextPanelUsxEditor = ({
+    shortName,
+    editable,
+    book,
+    chapter,
+    verse,
+    scrChapters,
+    updateScrRef,
+    onFocus,
+}: ScriptureTextPanelUsxProps) => {
+    useLayoutEffect(
+        () =>
+            console.debug(
+                `Performance<ScriptureTextPanelUsxEditor>: finished rendering at ${performance.now()} ms from start.`,
+            ),
+        [],
+    );
+
+    return (
+        <div className="text-panel" onFocus={onFocus}>
+            {scrChapters.map((scrChapter) => (
+                <UsxEditor
+                    key={scrChapter.chapter}
+                    usx={scrChapter.contents}
+                    paraMap={UsxEditorParaMap}
+                    charMap={UsxEditorCharMap}
+                    onUsxChanged={() => {}}
+                />
+            ))}
+        </div>
+    );
+};
+
+/** Scripture text panel that displays USX Scripture */
+export const ScriptureTextPanelUsx = ScriptureTextPanelHOC(
+    ScriptureTextPanelUsxEditor,
+    getScriptureUsx,
+);

--- a/react-electron-poc/src/renderer/components/panels/TextPanels/TextPanel.css
+++ b/react-electron-poc/src/renderer/components/panels/TextPanels/TextPanel.css
@@ -39,3 +39,12 @@
 .text-panel .search-result {
     background-color: #ffdd1e;
 }
+
+/* Overriding hard-coded styles set in the USX Editor */
+.text-panel .usxEditor {
+    width: auto !important;
+}
+
+.text-panel .usxMainEditor {
+    border: 0px solid !important;
+}

--- a/react-electron-poc/src/renderer/services/ScriptureService.ts
+++ b/react-electron-poc/src/renderer/services/ScriptureService.ts
@@ -175,16 +175,29 @@ export const getScriptureUsx = async (
     bookNum: number,
     chapter = -1,
 ): Promise<ScriptureChapterString[]> => {
+    const startGet = performance.now();
     try {
-        return chapter >= 0
-            ? await window.electronAPI.scripture
-                  .getScriptureChapterUsx(shortName, bookNum, chapter)
-                  .then((result) => [result])
-            : await window.electronAPI.scripture.getScriptureBookUsx(
-                  shortName,
-                  bookNum,
-              );
+        const scrChapterContents =
+            chapter >= 0
+                ? await window.electronAPI.scripture
+                      .getScriptureChapterUsx(shortName, bookNum, chapter)
+                      .then((result) => [result])
+                : await window.electronAPI.scripture.getScriptureBookUsx(
+                      shortName,
+                      bookNum,
+                  );
+        console.debug(
+            `Performance<ScriptureService.getScriptureUsx(${shortName}, ${bookNum}, ${chapter})>: took ${
+                performance.now() - startGet
+            } ms`,
+        );
+        return scrChapterContents;
     } catch (e) {
+        console.debug(
+            `Performance<ScriptureService.getScripture(${shortName}, ${bookNum}, ${chapter})>: Exception took ${
+                performance.now() - startGet
+            } ms`,
+        );
         console.log(e);
         return [
             {


### PR DESCRIPTION
- Made one-word markers like chapter and verse work properly.
- The cursor is placed in the appropriate locations when adding markers.
- Prepared for block-less text in USFM (which is probably a bug in Paratext but can happen) so the information is not deleted